### PR TITLE
[fix] admin-session-authenticate-delete

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Admin::SessionsController < Devise::SessionsController
-  before_action :authenticate_admin!
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in


### PR DESCRIPTION
セッションコントローラのauthenticateを削除